### PR TITLE
feat: automate OpenClaw gateway startup via cloud-init

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -141,3 +141,4 @@ This document tracks security assumptions, boundaries, and design decisions for 
 - [ ] Add automated checks (scripts or CI) that lint cloud-init and profiles for disallowed patterns.
 - [ ] Add example OpenClaw reverse-proxy + TLS configuration once the basic Podman path is stable.
 - [ ] Evaluate whether to build OpenClaw images inside Incus or pull prebuilt from a registry.
+- [ ] Replace `dangerouslyAllowHostHeaderOriginFallback` with explicit `gateway.controlUi.allowedOrigins` before any non-lab deployment.

--- a/cloud-init/openclaw-podman-skeleton.yml
+++ b/cloud-init/openclaw-podman-skeleton.yml
@@ -109,18 +109,12 @@ runcmd:
     echo "openclaw:100000:65536" >> /etc/subgid
     # Pre-create OpenClaw config so setup-podman.sh skips its own defaults.
     # The Quadlet uses --bind lan (non-loopback) so controlUi needs origin config.
+    # WARNING: dangerouslyAllowHostHeaderOriginFallback is for LAB USE ONLY.
+    # In production, replace with explicit gateway.controlUi.allowedOrigins list.
     mkdir -p /home/openclaw/.openclaw/workspace
     chmod 700 /home/openclaw/.openclaw /home/openclaw/.openclaw/workspace
-    cat > /home/openclaw/.openclaw/openclaw.json <<'OCJSON'
-    {
-      "gateway": {
-        "mode": "local",
-        "controlUi": {
-          "dangerouslyAllowHostHeaderOriginFallback": true
-        }
-      }
-    }
-    OCJSON
+    printf '{\n  "gateway": {\n    "mode": "local",\n    "controlUi": {\n      "dangerouslyAllowHostHeaderOriginFallback": true\n    }\n  }\n}\n' \
+      > /home/openclaw/.openclaw/openclaw.json
     chmod 600 /home/openclaw/.openclaw/openclaw.json
     chown -R openclaw:openclaw /home/openclaw/.openclaw
 
@@ -132,7 +126,6 @@ runcmd:
   # setup-podman.sh with QUADLET starts the service, but belt-and-suspenders.
   - |
     systemctl --machine openclaw@ --user daemon-reload || true
-    systemctl --machine openclaw@ --user enable openclaw.service || true
     systemctl --machine openclaw@ --user restart openclaw.service || true
 
   # Fix any root-owned files in openclaw's home


### PR DESCRIPTION
## Summary
- Rewrites `cloud-init/openclaw-podman-skeleton.yml` to fully automate OpenClaw gateway startup with no manual post-boot steps
- Adds AppArmor profiles to work around Ubuntu 24.04's `apparmor_restrict_unprivileged_userns=1` which blocks rootless Podman in Incus containers
- Configures `fuse-overlayfs` storage driver to avoid the 10+ minute `storage-chown-by-maps` delay with `--userns keep-id` on the 3GB OpenClaw image
- Pre-creates openclaw user, storage config, and gateway config before `setup-podman.sh` runs
- Updates `NOTES.md` with comprehensive lessons learned from iterative debugging

## Verification
Container `oc-exp-1772387677` on k8s-delta boots from this cloud-init and produces:
- `openclaw` user with home directory
- Rootless Podman functional (fuse-overlayfs)
- `openclaw.service` active (running) via Quadlet
- `curl http://127.0.0.1:18789/` returns HTTP 200

## Test plan
- [ ] Launch a fresh container with `bash scripts/launch-experiment.sh oc-exp-test k8s-delta`
- [ ] Wait for cloud-init: `incus exec k8s-delta:oc-exp-test -- cloud-init status --wait`
- [ ] Verify gateway responds: `incus exec k8s-delta:oc-exp-test -- curl -s http://127.0.0.1:18789/`
- [ ] Verify service: `incus exec k8s-delta:oc-exp-test -- systemctl --machine openclaw@ --user status openclaw.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)